### PR TITLE
surnia: Set camera permissions device specific

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -28,6 +28,10 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/audio/audio_platform_info.xml:system/etc/audio_platform_info.xml \
     $(LOCAL_PATH)/audio/mixer_paths.xml:system/etc/mixer_paths.xml
 
+# Camera
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.camera.autofocus.xml:system/etc/permissions/android.hardware.camera.autofocus.xml
+
 # Media
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/media_codecs.xml:system/etc/media_codecs.xml \


### PR DESCRIPTION
This commit is a followup to the msm8916 commit.
This just enables right camera permission into the device.mk

Change-Id: If509d3407db3e30b29ab6e5d684df3f7c020ff22